### PR TITLE
本棚のページに、新規登録後の読書記録も表示されるように修正しました。

### DIFF
--- a/src/main/java/beans/ReadingRecBean.java
+++ b/src/main/java/beans/ReadingRecBean.java
@@ -10,7 +10,6 @@ public class ReadingRecBean implements Serializable{
   private String title;
   private String author;
   private String readStatus;
-  private int readStatusLength;
   
   
   public ReadingRecBean() { }
@@ -34,9 +33,6 @@ public class ReadingRecBean implements Serializable{
   
   public String getReadStatus() { return readStatus; }
   public void setReadStatus(String readStatus) { this.readStatus = readStatus; }
-  
-  public int getReadStatusLength() { return readStatusLength; }
-  public void setReadStatusLength(int readStatusLength) { this.readStatusLength = readStatusLength; }
   
   
 }

--- a/src/main/java/dao/ReadingRecAddDAO.java
+++ b/src/main/java/dao/ReadingRecAddDAO.java
@@ -18,9 +18,9 @@ public class ReadingRecAddDAO {
   private final String DB_USER = "root";
   private final String DB_PASS = "moo0921too";
 
-  
-  public boolean create(ReadingRecBean readingRec) {
-	  
+  //本棚に本を追加
+  public boolean create(ReadingRecBean rec) {
+		
 	//JDBCドライバを読み込む
     try {
         Class.forName("com.mysql.cj.jdbc.Driver");
@@ -39,16 +39,16 @@ public class ReadingRecAddDAO {
       PreparedStatement pStmt = conn.prepareStatement(sql);
       
       //WHERE文の?に代入
-      pStmt.setString(1, readingRec.getTitle());
-      pStmt.setString(2, readingRec.getAuthor());
-      pStmt.setString(3, readingRec.getReadStatus());
+      pStmt.setString(1, rec.getTitle());
+      pStmt.setString(2, rec.getAuthor());
+      pStmt.setString(3, rec.getReadStatus());
       
       // INSERT文を実行（resultには追加された行数が代入される）
       int result = pStmt.executeUpdate();
       if (result != 1) {
         return false;
       }
-	      
+            
     }  
       //try文の中でエラーが出たとき実行する
     catch (SQLException e) {
@@ -60,6 +60,7 @@ public class ReadingRecAddDAO {
     return true;
   }
   
+  //読書記録の一覧を取得
   public List<ReadingRecBean> findAll() {
 	    List<ReadingRecBean> readingRecList = new ArrayList<>();
   
@@ -82,13 +83,13 @@ public class ReadingRecAddDAO {
 	        ResultSet rs = pStmt.executeQuery();
 
 	        // 結果表に格納されたレコードの内容を
-	        // readingRec2インスタンスに設定し、readingRecListインスタンスに追加
+	        // record2インスタンスに設定し、readingRecListインスタンスに追加
 	        while (rs.next()) {
 	          String title = rs.getString("タイトル");
 	          String author = rs.getString("作者");
 	          String readStatus = rs.getString("読書状況");
-	          ReadingRecBean readingRec2 = new ReadingRecBean(title, author, readStatus);
-	          readingRecList.add(readingRec2);
+	          ReadingRecBean record2 = new ReadingRecBean(title, author, readStatus);
+	          readingRecList.add(record2);
 	        }
 	    }   catch (SQLException e) {
 	          e.printStackTrace();

--- a/src/main/java/model/ReadingRecAddLogic.java
+++ b/src/main/java/model/ReadingRecAddLogic.java
@@ -1,0 +1,14 @@
+//「スッキリわかるサーブレット＆JSP入門」P298のコード10-14、55行目～69行目参考
+
+package model;
+
+import java.util.List;
+
+import beans.ReadingRecBean;
+
+public class ReadingRecAddLogic {
+
+  public void execute(ReadingRecBean readingRec, List<ReadingRecBean> readingRecList){
+	  readingRecList.add(0, readingRec);
+  }
+}

--- a/src/main/java/servlet/Login.java
+++ b/src/main/java/servlet/Login.java
@@ -44,7 +44,7 @@ public class Login extends HttpServlet {
 	//アカウントIDが見つかったとき
     //ログイン成功
     else {
-    	//セッションスコープに保存。 myPage.jspや本棚でEL式を使うため。
+    	//セッションスコープに保存。 マイページや本棚でEL式を使うため。
     	HttpSession session = request.getSession();
     	session.setAttribute("account", account);
     	
@@ -52,7 +52,7 @@ public class Login extends HttpServlet {
     	ReadingRecAddDAO dao2 = new ReadingRecAddDAO();
     	List<ReadingRecBean> readingRecList = dao2.findAll();
     	
-    	//bookShelf.jspで使うため、セッションスコープに保存。
+    	//「bookShelf.jsp」、「ReadingRecAdd.java」で使うため、セッションスコープに保存。
     	HttpSession session2 = request.getSession();
     	session2.setAttribute("readingRecList", readingRecList);
     	

--- a/src/main/java/servlet/ReadingRecAdd.java
+++ b/src/main/java/servlet/ReadingRecAdd.java
@@ -1,4 +1,7 @@
 //「スッキリわかるサーブレット＆JSP入門」P298のコード10-14、55行目～69行目参考
+//P298のコード10-13
+
+//本棚に読書記録を追加する
 
 package servlet;
 
@@ -13,6 +16,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 @WebServlet("/ReadingRecAdd")
 public class ReadingRecAdd extends HttpServlet {
@@ -28,14 +32,23 @@ public class ReadingRecAdd extends HttpServlet {
     //入力情報をインスタンスに保存
     ReadingRecBean readingRec = new ReadingRecBean(title, author, readStatus);
     
+    //データベースyondaの読書状況に読書記録追加
     ReadingRecAddDAO dao = new ReadingRecAddDAO();
     boolean Rec = dao.create(readingRec);
     
     //追加できたとき
 	if(Rec) {
 		
-		List<ReadingRecBean> readingRecList = dao.findAll();
-		System.out.println(readingRecList);
+		//登録済みの読書記録を取得
+		HttpSession session = request.getSession();
+		@SuppressWarnings("unchecked")  //一行下のコードの警告対策。「ReadingRecBean」だと警告は出ないが、Listがついてると出てしまう。
+		List<ReadingRecBean> recList = (List<ReadingRecBean>)session.getAttribute("readingRecList");
+		
+		//リストの先頭に追加。「0」で先頭にしている。
+		recList.add(0, readingRec);
+		
+		//「readingRecList」のように、取得先と同じ名前で保存
+		session.setAttribute("readingRecList", recList);
 		
 		response.sendRedirect("http://localhost:8080/yonda/readingRecAddResult.jsp"); 
 	}

--- a/src/main/webapp/bookShelf.jsp
+++ b/src/main/webapp/bookShelf.jsp
@@ -6,7 +6,7 @@
 <%@ page import="java.util.List"%>
     
 <%
-//セッションスコープに保存されたデータを取得
+//Login.javaでセッションスコープに保存したデータを取得
  List<ReadingRecBean> readingRecList = (List<ReadingRecBean>)session.getAttribute("readingRecList");
 %>
 


### PR DESCRIPTION
サーバーを再起動して本棚に行くことで、最新の読書記録を表示させていましたが、新規登録後に本棚のページに戻るだけで表示されるようになってます！

The bookshelf page has been modified to display reading records after new registration.

The latest reading records were displayed by restarting the server and going to the bookshelf, but now they are displayed just by returning to the bookshelf page after registering!