### PR TITLE
データベースに接続する際に必要な情報(JDBC_URLなど)が、DAOファイル5つ全て同じであるため、ConfigDB.javaに入れました。

### DIFF
--- a/src/main/java/dao/AccountEntryDAO.java
+++ b/src/main/java/dao/AccountEntryDAO.java
@@ -9,23 +9,14 @@ import java.sql.SQLException;
 
 import beans.AccountBean;
 
-public class AccountEntryDAO {
-  // データベース接続に使用する情報
-  private final String JDBC_URL = "jdbc:mysql://localhost:3306/yonda";
-  private final String DB_USER = "root";
-  private final String DB_PASS = "moo0921too";
+public class AccountEntryDAO extends ConfigDB{
 
-  
+	
   public boolean create(AccountBean account) {
 	  
-	//JDBCドライバを読み込む
-    try {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-    }
-    //JDBCドライバが読み込めないとき実行する    
-    catch (ClassNotFoundException e) {
-        throw new IllegalStateException("JDBCドライバを読み込めませんでした");
-    }
+	//親クラスConfigDBのメソッドを利用
+	//JDBCドライバーを読み込む
+		ReadJDBC_Driver();
     
     // データベースへ接続
     try (Connection conn = DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASS)) {

--- a/src/main/java/dao/ConfigDB.java
+++ b/src/main/java/dao/ConfigDB.java
@@ -1,0 +1,25 @@
+//https://www.sejuku.net/blog/24926
+//https://magazine.techacademy.jp/magazine/9246
+
+package dao;
+
+public class ConfigDB{
+  
+   final String JDBC_URL = "jdbc:mysql://localhost:3306/yonda";
+   final String DB_USER = "root";
+   final String DB_PASS = "moo0921too";
+   
+   
+   public void ReadJDBC_Driver() {
+	 //MySQL用のJDBCドライバを読み込む
+     try {
+         Class.forName("com.mysql.cj.jdbc.Driver");
+     }
+     //JDBCドライバが読み込めないとき実行する    
+     catch (ClassNotFoundException e) {
+         throw new IllegalStateException("JDBCドライバを読み込めませんでした");
+     }
+	    
+   }
+}
+

--- a/src/main/java/dao/LoginDAO.java
+++ b/src/main/java/dao/LoginDAO.java
@@ -10,28 +10,18 @@ import java.sql.SQLException;
 
 import beans.AccountBean;
 
-public class LoginDAO {
-  // データベース接続に使用する情報
-  private final String JDBC_URL = "jdbc:mysql://localhost:3306/yonda";
-  private final String DB_USER = "root";
-  private final String DB_PASS = "moo0921too";
-
+//ConfigDB.javaのConfigDBクラスを継承。
+//JDBC_URL、DB_USER、DB_PASSがLoginDAOクラスで使えるようになる。
+public class LoginDAO extends ConfigDB{
   
-//６５行目の「return accountID」ができるよう初期設定しておく。
+  //６５行目の「return accountID」ができるよう初期設定しておく。
   AccountBean accountID = null;
   
   
   public AccountBean findAccountID(AccountBean account) {
-	  
-	  
-    //JDBCドライバを読み込む
-    try {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-    }
-    //JDBCドライバが読み込めない（try文の中でエラーが出た）とき実行する    
-    catch (ClassNotFoundException e) {
-        throw new IllegalStateException("JDBCドライバを読み込めませんでした");
-    }
+	 
+	//親クラスConfigDBのメソッドを利用
+	ReadJDBC_Driver();
     
     // データベースへ接続
     try (Connection conn = DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASS)) {

--- a/src/main/java/dao/RePassDAO.java
+++ b/src/main/java/dao/RePassDAO.java
@@ -8,23 +8,13 @@ import java.sql.SQLException;
 
 import beans.AccountBean;
 
-public class RePassDAO {
-  // データベース接続に使用する情報
-  private final String JDBC_URL = "jdbc:mysql://localhost:3306/yonda";
-  private final String DB_USER = "root";
-  private final String DB_PASS = "moo0921too";
-
+public class RePassDAO extends ConfigDB{
   
+	
   public void rePass(AccountBean account, AccountBean account2) {
 	   
-	//JDBCドライバを読み込む
-    try {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-    }
-    //JDBCドライバが読み込めないとき実行する    
-    catch (ClassNotFoundException e) {
-        throw new IllegalStateException("JDBCドライバを読み込めませんでした");
-    }
+	//親クラスConfigDBのメソッドを利用
+		ReadJDBC_Driver();
     
     // データベースへ接続
     try (Connection conn = DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASS)) {

--- a/src/main/java/dao/RePassIdDAO.java
+++ b/src/main/java/dao/RePassIdDAO.java
@@ -10,26 +10,17 @@ import java.sql.SQLException;
 
 import beans.AccountBean;
 
-public class RePassIdDAO {
-  // データベース接続に使用する情報
-  private final String JDBC_URL = "jdbc:mysql://localhost:3306/yonda";
-  private final String DB_USER = "root";
-  private final String DB_PASS = "moo0921too";
+public class RePassIdDAO extends ConfigDB{
   
+	
   //63行目の「return accountID」ができるよう初期設定しておく。
   AccountBean accountID = null;
   
   public AccountBean findAccountID(AccountBean account) {
 	  
-	//JDBCドライバを読み込む
-    try {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-    }
-    //JDBCドライバが読み込めないとき実行する    
-    catch (ClassNotFoundException e) {
-        throw new IllegalStateException("JDBCドライバを読み込めませんでした");
-    }
-    
+	//親クラスConfigDBのメソッドを利用
+		ReadJDBC_Driver();
+	
     // データベースへ接続
     try (Connection conn = DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASS)) {
     	

--- a/src/main/java/dao/ReadingRecAddDAO.java
+++ b/src/main/java/dao/ReadingRecAddDAO.java
@@ -12,23 +12,13 @@ import java.util.List;
 
 import beans.ReadingRecBean;
 
-public class ReadingRecAddDAO {
-  // データベース接続に使用する情報
-  private final String JDBC_URL = "jdbc:mysql://localhost:3306/yonda";
-  private final String DB_USER = "root";
-  private final String DB_PASS = "moo0921too";
-
+public class ReadingRecAddDAO extends ConfigDB{
+  
   //本棚に本を追加
   public boolean create(ReadingRecBean rec) {
 		
-	//JDBCドライバを読み込む
-    try {
-        Class.forName("com.mysql.cj.jdbc.Driver");
-    }
-    //JDBCドライバが読み込めないとき実行する    
-    catch (ClassNotFoundException e) {
-        throw new IllegalStateException("JDBCドライバを読み込めませんでした");
-    }
+	//親クラスConfigDBのメソッドを利用
+		ReadJDBC_Driver();
     
     // データベースへ接続
     try (Connection conn = DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASS)) {
@@ -65,13 +55,8 @@ public class ReadingRecAddDAO {
 	    List<ReadingRecBean> readingRecList = new ArrayList<>();
   
 	  //JDBCドライバを読み込む
-	    try {
-	        Class.forName("com.mysql.cj.jdbc.Driver");
-	    }
-	    //JDBCドライバが読み込めないとき実行する    
-	    catch (ClassNotFoundException e) {
-	        throw new IllegalStateException("JDBCドライバを読み込めませんでした");
-	    }
+	  //親クラスConfigDBのメソッドを利用
+		ReadJDBC_Driver();
 	    
 	    // データベースへ接続
 	    try (Connection conn = DriverManager.getConnection(JDBC_URL, DB_USER, DB_PASS)) {

--- a/src/main/java/servlet/ReadingRecAdd.java
+++ b/src/main/java/servlet/ReadingRecAdd.java
@@ -44,13 +44,15 @@ public class ReadingRecAdd extends HttpServlet {
 		@SuppressWarnings("unchecked")  //一行下のコードの警告対策。「ReadingRecBean」だと警告は出ないが、Listがついてると出てしまう。
 		List<ReadingRecBean> recList = (List<ReadingRecBean>)session.getAttribute("readingRecList");
 		
-		//リストの先頭に追加。「0」で先頭にしている。
-		recList.add(0, readingRec);
+		//リストの一番後ろに追加。
+		recList.add(readingRec);
 		
 		//「readingRecList」のように、取得先と同じ名前で保存
 		session.setAttribute("readingRecList", recList);
 		
 		response.sendRedirect("http://localhost:8080/yonda/readingRecAddResult.jsp"); 
+	
+	    //request.getAttribute("addRec");
 	}
 	
 	//追加できなかったとき


### PR DESCRIPTION
それに伴い、5つのDAOファイルのクラスは、すべてConfigDBを継承するように変更。

DB_PASSなどを修正するときは、ConfigDBのDB_PASSだけでいいので修正が楽になってます!

DAOファイルをさらに読みやすくするため、JDBCドライバを読み込む処理を、親クラスConfigDBのメソッドとして定義しています。